### PR TITLE
Force Jenkins restart when its config file is set up

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -2,7 +2,7 @@
 # Handle plugins
 - name: "{{ startup_delay_s | default(10) }}s delay while starting Jenkins"
   wait_for: host=localhost port={{ port }} delay={{ startup_delay_s | default(10) }}
-  when: jenkins_install.changed or config_changed.changed
+  when: jenkins_install.changed or config_changed
 
 - name: "Create Jenkins CLI destination directory: {{ jenkins_dest }}"
   file: path={{ jenkins_dest }} state=directory

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,22 +1,29 @@
 ---
 
+# NOTE: in this playbook the 'config_changed' variable was set multiple times even a task
+# is skipped (see https://github.com/ansible/ansible/issues/4297) which means that in some
+# case Jenkins won't restart even if the config file was changed.
+
 - name: Create jenkins configuration for RedHat
   file: path=/etc/sysconfig/jenkins state=touch
   when: ansible_os_family == "RedHat"
 
 - name: Configure Jenkins Port for RedHat
   lineinfile: dest=/etc/sysconfig/jenkins regexp=^JENKINS_PORT= line=JENKINS_PORT={{port}}
-  register: config_changed
+  register: rh_config_changed
   when: ansible_os_family == "RedHat"
 
 - name: Configure Jenkins Port for Debian
   lineinfile: dest=/etc/default/jenkins regexp=^HTTP_PORT= line=HTTP_PORT={{port}}
-  register: config_changed
+  register: deb_config_changed
   when: ansible_os_family == "Debian"
+
+- set_fact:
+    config_changed: "{{ rh_config_changed.changed or deb_config_changed.changed }}"
 
 - name: Restart jenkins now
   service: name=jenkins state=restarted
-  when: config_changed.changed
+  when: config_changed
 
 - name: Configure Jenkins Prefix for RedHat
   when: prefix is defined and ansible_os_family == "RedHat"


### PR DESCRIPTION
In the [tasks/config.yml](https://github.com/fupelaqu/ansible-jenkins/blob/development/tasks/config.yml) playbook the `config_changed` variable was set multiple times even a task is skipped "see [this](https://github.com/ansible/ansible/issues/4297)" which means that in some case Jenkins won't restart even if the config file was changed.
